### PR TITLE
update location option with window.open - Chrome Issue

### DIFF
--- a/src/google-oauth2.js
+++ b/src/google-oauth2.js
@@ -180,7 +180,7 @@ GO2.prototype = {
             ',height=' + this._popupHeight +
             ',top=' + top +
             ',left=' + left +
-            ',location=yes,toolbar=no,menubar=no';
+            ',location=no,toolbar=no,menubar=no';
         this._popupWindow = window.open(url, this.WINDOW_NAME, windowFeatures);
     },
 


### PR DESCRIPTION
Apparently, the Oauth web client is opened in a new browser tab instead of a modal. I noticed it in the last 2-3 weeks and it seems to be related to chrome. I made a change to set the location=no option instead of location=yes which resolves the issue and keeps everything intact. 

I also suggest to add an option for the user to overwrite some of these options, something like the current height/width, but more general. So if the existing options are 'location=no,width=xxx', the use will be able to append some options and in that way, overwrite the prev options: 'location=no,width=xxx,<append at the end>location=yes'. 

